### PR TITLE
moved the export CSV functionality to a button rather than an on-closing checkbox

### DIFF
--- a/RaceAdmin/RaceAdmin/DefaultCautionHandler.cs
+++ b/RaceAdmin/RaceAdmin/DefaultCautionHandler.cs
@@ -49,7 +49,8 @@ namespace RaceAdmin
         {
             // start a timer to flash the caution panel
             timer = new System.Threading.Timer(
-                callback: new System.Threading.TimerCallback(o => {
+                callback: new System.Threading.TimerCallback(o =>
+                {
                     cautionPanel.BackColor = NextColor(cautionPanel.BackColor);
                 }),
                 state: null,

--- a/RaceAdmin/RaceAdmin/Form1.Designer.cs
+++ b/RaceAdmin/RaceAdmin/Form1.Designer.cs
@@ -36,11 +36,6 @@
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle6 = new System.Windows.Forms.DataGridViewCellStyle();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(RaceAdminMain));
             this.IncidentsTableView = new System.Windows.Forms.DataGridView();
-            this.CarNum = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.DriverName = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Incident = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Total = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.DriverLapNum = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.TotalIncidentCountLabel = new System.Windows.Forms.Label();
             this.TotalIncidentCountNum = new System.Windows.Forms.Label();
             this.IncidentsSinceCautionLabel = new System.Windows.Forms.Label();
@@ -51,6 +46,11 @@
             this.ExportToCsvCheckBox = new System.Windows.Forms.CheckBox();
             this.label4 = new System.Windows.Forms.Label();
             this.AudioNotificationCheckBox = new System.Windows.Forms.CheckBox();
+            this.CarNum = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.DriverName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Incident = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Total = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.DriverLapNum = new System.Windows.Forms.DataGridViewTextBoxColumn();
             ((System.ComponentModel.ISupportInitialize)(this.IncidentsTableView)).BeginInit();
             this.SuspendLayout();
             // 
@@ -101,94 +101,7 @@
             this.IncidentsTableView.Size = new System.Drawing.Size(591, 309);
             this.IncidentsTableView.TabIndex = 0;
             this.IncidentsTableView.TabStop = false;
-            // 
-            // CarNum
-            // 
-            this.CarNum.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.ControlLight;
-            dataGridViewCellStyle2.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
-            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.Color.Black;
-            dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.CarNum.DefaultCellStyle = dataGridViewCellStyle2;
-            this.CarNum.DividerWidth = 1;
-            this.CarNum.HeaderText = "Car #";
-            this.CarNum.MinimumWidth = 75;
-            this.CarNum.Name = "CarNum";
-            this.CarNum.ReadOnly = true;
-            this.CarNum.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            this.CarNum.Width = 75;
-            // 
-            // DriverName
-            // 
-            this.DriverName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            dataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.ControlLight;
-            dataGridViewCellStyle3.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle3.SelectionBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
-            dataGridViewCellStyle3.SelectionForeColor = System.Drawing.Color.Black;
-            dataGridViewCellStyle3.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.DriverName.DefaultCellStyle = dataGridViewCellStyle3;
-            this.DriverName.DividerWidth = 1;
-            this.DriverName.HeaderText = "Driver Name";
-            this.DriverName.MinimumWidth = 250;
-            this.DriverName.Name = "DriverName";
-            this.DriverName.ReadOnly = true;
-            this.DriverName.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            // 
-            // Incident
-            // 
-            this.Incident.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            dataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            dataGridViewCellStyle4.BackColor = System.Drawing.SystemColors.ControlLight;
-            dataGridViewCellStyle4.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle4.SelectionBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
-            dataGridViewCellStyle4.SelectionForeColor = System.Drawing.Color.Black;
-            dataGridViewCellStyle4.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.Incident.DefaultCellStyle = dataGridViewCellStyle4;
-            this.Incident.DividerWidth = 1;
-            this.Incident.HeaderText = "Inc.";
-            this.Incident.MinimumWidth = 75;
-            this.Incident.Name = "Incident";
-            this.Incident.ReadOnly = true;
-            this.Incident.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            this.Incident.Width = 75;
-            // 
-            // Total
-            // 
-            this.Total.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            dataGridViewCellStyle5.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            dataGridViewCellStyle5.BackColor = System.Drawing.SystemColors.ControlLight;
-            dataGridViewCellStyle5.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle5.SelectionBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
-            dataGridViewCellStyle5.SelectionForeColor = System.Drawing.Color.Black;
-            dataGridViewCellStyle5.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.Total.DefaultCellStyle = dataGridViewCellStyle5;
-            this.Total.DividerWidth = 1;
-            this.Total.HeaderText = "Total";
-            this.Total.MinimumWidth = 75;
-            this.Total.Name = "Total";
-            this.Total.ReadOnly = true;
-            this.Total.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            this.Total.Width = 75;
-            // 
-            // DriverLapNum
-            // 
-            this.DriverLapNum.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            dataGridViewCellStyle6.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            dataGridViewCellStyle6.BackColor = System.Drawing.SystemColors.ControlLight;
-            dataGridViewCellStyle6.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle6.SelectionBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
-            dataGridViewCellStyle6.SelectionForeColor = System.Drawing.Color.Black;
-            dataGridViewCellStyle6.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.DriverLapNum.DefaultCellStyle = dataGridViewCellStyle6;
-            this.DriverLapNum.HeaderText = "Driver Lap #";
-            this.DriverLapNum.MinimumWidth = 93;
-            this.DriverLapNum.Name = "DriverLapNum";
-            this.DriverLapNum.ReadOnly = true;
-            this.DriverLapNum.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            this.DriverLapNum.Width = 93;
+            this.IncidentsTableView.SortCompare += new System.Windows.Forms.DataGridViewSortCompareEventHandler(this.IncidentsTableView_SortCompare);
             // 
             // TotalIncidentCountLabel
             // 
@@ -309,6 +222,94 @@
             this.AudioNotificationCheckBox.Text = "Use audio notification";
             this.AudioNotificationCheckBox.UseVisualStyleBackColor = true;
             this.AudioNotificationCheckBox.CheckedChanged += new System.EventHandler(this.AudioNotificationCheckBox_CheckedChanged);
+            // 
+            // CarNum
+            // 
+            this.CarNum.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.ControlLight;
+            dataGridViewCellStyle2.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
+            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.Color.Black;
+            dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.CarNum.DefaultCellStyle = dataGridViewCellStyle2;
+            this.CarNum.DividerWidth = 1;
+            this.CarNum.HeaderText = "Car #";
+            this.CarNum.MinimumWidth = 75;
+            this.CarNum.Name = "CarNum";
+            this.CarNum.ReadOnly = true;
+            this.CarNum.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            this.CarNum.Width = 75;
+            // 
+            // DriverName
+            // 
+            this.DriverName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            dataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.ControlLight;
+            dataGridViewCellStyle3.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle3.SelectionBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
+            dataGridViewCellStyle3.SelectionForeColor = System.Drawing.Color.Black;
+            dataGridViewCellStyle3.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.DriverName.DefaultCellStyle = dataGridViewCellStyle3;
+            this.DriverName.DividerWidth = 1;
+            this.DriverName.HeaderText = "Driver Name";
+            this.DriverName.MinimumWidth = 250;
+            this.DriverName.Name = "DriverName";
+            this.DriverName.ReadOnly = true;
+            this.DriverName.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            // 
+            // Incident
+            // 
+            this.Incident.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            dataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            dataGridViewCellStyle4.BackColor = System.Drawing.SystemColors.ControlLight;
+            dataGridViewCellStyle4.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle4.SelectionBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
+            dataGridViewCellStyle4.SelectionForeColor = System.Drawing.Color.Black;
+            dataGridViewCellStyle4.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.Incident.DefaultCellStyle = dataGridViewCellStyle4;
+            this.Incident.DividerWidth = 1;
+            this.Incident.HeaderText = "Inc.";
+            this.Incident.MinimumWidth = 75;
+            this.Incident.Name = "Incident";
+            this.Incident.ReadOnly = true;
+            this.Incident.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            this.Incident.Width = 75;
+            // 
+            // Total
+            // 
+            this.Total.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            dataGridViewCellStyle5.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            dataGridViewCellStyle5.BackColor = System.Drawing.SystemColors.ControlLight;
+            dataGridViewCellStyle5.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle5.SelectionBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
+            dataGridViewCellStyle5.SelectionForeColor = System.Drawing.Color.Black;
+            dataGridViewCellStyle5.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.Total.DefaultCellStyle = dataGridViewCellStyle5;
+            this.Total.DividerWidth = 1;
+            this.Total.HeaderText = "Total";
+            this.Total.MinimumWidth = 75;
+            this.Total.Name = "Total";
+            this.Total.ReadOnly = true;
+            this.Total.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            this.Total.Width = 75;
+            // 
+            // DriverLapNum
+            // 
+            this.DriverLapNum.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            dataGridViewCellStyle6.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            dataGridViewCellStyle6.BackColor = System.Drawing.SystemColors.ControlLight;
+            dataGridViewCellStyle6.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle6.SelectionBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
+            dataGridViewCellStyle6.SelectionForeColor = System.Drawing.Color.Black;
+            dataGridViewCellStyle6.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.DriverLapNum.DefaultCellStyle = dataGridViewCellStyle6;
+            this.DriverLapNum.HeaderText = "Driver Lap #";
+            this.DriverLapNum.MinimumWidth = 110;
+            this.DriverLapNum.Name = "DriverLapNum";
+            this.DriverLapNum.ReadOnly = true;
+            this.DriverLapNum.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            this.DriverLapNum.Width = 110;
             // 
             // RaceAdminMain
             // 

--- a/RaceAdmin/RaceAdmin/Form1.Designer.cs
+++ b/RaceAdmin/RaceAdmin/Form1.Designer.cs
@@ -36,6 +36,11 @@
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle6 = new System.Windows.Forms.DataGridViewCellStyle();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(RaceAdminMain));
             this.IncidentsTableView = new System.Windows.Forms.DataGridView();
+            this.CarNum = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.DriverName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Incident = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Total = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.DriverLapNum = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.TotalIncidentCountLabel = new System.Windows.Forms.Label();
             this.TotalIncidentCountNum = new System.Windows.Forms.Label();
             this.IncidentsSinceCautionLabel = new System.Windows.Forms.Label();
@@ -43,14 +48,9 @@
             this.IncsRequiredForCautionTextBox = new System.Windows.Forms.TextBox();
             this.label2 = new System.Windows.Forms.Label();
             this.CautionPanel = new System.Windows.Forms.Panel();
-            this.ExportToCsvCheckBox = new System.Windows.Forms.CheckBox();
             this.label4 = new System.Windows.Forms.Label();
             this.AudioNotificationCheckBox = new System.Windows.Forms.CheckBox();
-            this.CarNum = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.DriverName = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Incident = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Total = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.DriverLapNum = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ExportButton = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.IncidentsTableView)).BeginInit();
             this.SuspendLayout();
             // 
@@ -98,130 +98,10 @@
             this.IncidentsTableView.ShowCellToolTips = false;
             this.IncidentsTableView.ShowEditingIcon = false;
             this.IncidentsTableView.ShowRowErrors = false;
-            this.IncidentsTableView.Size = new System.Drawing.Size(591, 309);
+            this.IncidentsTableView.Size = new System.Drawing.Size(591, 329);
             this.IncidentsTableView.TabIndex = 0;
             this.IncidentsTableView.TabStop = false;
             this.IncidentsTableView.SortCompare += new System.Windows.Forms.DataGridViewSortCompareEventHandler(this.IncidentsTableView_SortCompare);
-            // 
-            // TotalIncidentCountLabel
-            // 
-            this.TotalIncidentCountLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.TotalIncidentCountLabel.Font = new System.Drawing.Font("Arial", 24F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.TotalIncidentCountLabel.Location = new System.Drawing.Point(663, 31);
-            this.TotalIncidentCountLabel.Margin = new System.Windows.Forms.Padding(0);
-            this.TotalIncidentCountLabel.Name = "TotalIncidentCountLabel";
-            this.TotalIncidentCountLabel.Size = new System.Drawing.Size(288, 42);
-            this.TotalIncidentCountLabel.TabIndex = 2;
-            this.TotalIncidentCountLabel.Text = "Total Incidents";
-            this.TotalIncidentCountLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // TotalIncidentCountNum
-            // 
-            this.TotalIncidentCountNum.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.TotalIncidentCountNum.Font = new System.Drawing.Font("Arial", 60F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.TotalIncidentCountNum.Location = new System.Drawing.Point(663, 73);
-            this.TotalIncidentCountNum.Margin = new System.Windows.Forms.Padding(0);
-            this.TotalIncidentCountNum.Name = "TotalIncidentCountNum";
-            this.TotalIncidentCountNum.Size = new System.Drawing.Size(288, 100);
-            this.TotalIncidentCountNum.TabIndex = 2;
-            this.TotalIncidentCountNum.Text = "0";
-            this.TotalIncidentCountNum.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // IncidentsSinceCautionLabel
-            // 
-            this.IncidentsSinceCautionLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.IncidentsSinceCautionLabel.Font = new System.Drawing.Font("Arial", 24F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.IncidentsSinceCautionLabel.Location = new System.Drawing.Point(663, 172);
-            this.IncidentsSinceCautionLabel.Margin = new System.Windows.Forms.Padding(0);
-            this.IncidentsSinceCautionLabel.Name = "IncidentsSinceCautionLabel";
-            this.IncidentsSinceCautionLabel.Size = new System.Drawing.Size(288, 42);
-            this.IncidentsSinceCautionLabel.TabIndex = 2;
-            this.IncidentsSinceCautionLabel.Text = "Since Last Caution";
-            this.IncidentsSinceCautionLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // IncidentsSinceCautionNum
-            // 
-            this.IncidentsSinceCautionNum.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.IncidentsSinceCautionNum.Font = new System.Drawing.Font("Arial", 60F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.IncidentsSinceCautionNum.Location = new System.Drawing.Point(663, 214);
-            this.IncidentsSinceCautionNum.Margin = new System.Windows.Forms.Padding(0);
-            this.IncidentsSinceCautionNum.Name = "IncidentsSinceCautionNum";
-            this.IncidentsSinceCautionNum.Size = new System.Drawing.Size(288, 100);
-            this.IncidentsSinceCautionNum.TabIndex = 2;
-            this.IncidentsSinceCautionNum.Text = "0";
-            this.IncidentsSinceCautionNum.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // IncsRequiredForCautionTextBox
-            // 
-            this.IncsRequiredForCautionTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.IncsRequiredForCautionTextBox.Location = new System.Drawing.Point(766, 338);
-            this.IncsRequiredForCautionTextBox.Name = "IncsRequiredForCautionTextBox";
-            this.IncsRequiredForCautionTextBox.Size = new System.Drawing.Size(74, 20);
-            this.IncsRequiredForCautionTextBox.TabIndex = 3;
-            this.IncsRequiredForCautionTextBox.Text = "0";
-            this.IncsRequiredForCautionTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.IncsRequiredForCautionTextBox.KeyUp += new System.Windows.Forms.KeyEventHandler(this.IncsRequiredForCautionTextBox_KeyUp);
-            // 
-            // label2
-            // 
-            this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.label2.Font = new System.Drawing.Font("Arial", 9.75F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label2.Location = new System.Drawing.Point(663, 361);
-            this.label2.Margin = new System.Windows.Forms.Padding(0);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(288, 23);
-            this.label2.TabIndex = 2;
-            this.label2.Text = "(Enter to confirm)";
-            this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // CautionPanel
-            // 
-            this.CautionPanel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.CautionPanel.BackColor = System.Drawing.SystemColors.Control;
-            this.CautionPanel.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.CautionPanel.Location = new System.Drawing.Point(12, 12);
-            this.CautionPanel.MinimumSize = new System.Drawing.Size(568, 273);
-            this.CautionPanel.Name = "CautionPanel";
-            this.CautionPanel.Size = new System.Drawing.Size(591, 273);
-            this.CautionPanel.TabIndex = 4;
-            // 
-            // ExportToCsvCheckBox
-            // 
-            this.ExportToCsvCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.ExportToCsvCheckBox.AutoSize = true;
-            this.ExportToCsvCheckBox.Font = new System.Drawing.Font("Arial", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.ExportToCsvCheckBox.Location = new System.Drawing.Point(684, 578);
-            this.ExportToCsvCheckBox.Name = "ExportToCsvCheckBox";
-            this.ExportToCsvCheckBox.Size = new System.Drawing.Size(237, 20);
-            this.ExportToCsvCheckBox.TabIndex = 5;
-            this.ExportToCsvCheckBox.Text = "Export incident table to csv on close";
-            this.ExportToCsvCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // label4
-            // 
-            this.label4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.label4.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label4.Location = new System.Drawing.Point(663, 312);
-            this.label4.Margin = new System.Windows.Forms.Padding(0);
-            this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(288, 23);
-            this.label4.TabIndex = 2;
-            this.label4.Text = "Incs required for caution";
-            this.label4.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // AudioNotificationCheckBox
-            // 
-            this.AudioNotificationCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.AudioNotificationCheckBox.AutoSize = true;
-            this.AudioNotificationCheckBox.Font = new System.Drawing.Font("Arial", 9.75F);
-            this.AudioNotificationCheckBox.Location = new System.Drawing.Point(684, 555);
-            this.AudioNotificationCheckBox.Name = "AudioNotificationCheckBox";
-            this.AudioNotificationCheckBox.Size = new System.Drawing.Size(151, 20);
-            this.AudioNotificationCheckBox.TabIndex = 6;
-            this.AudioNotificationCheckBox.Text = "Use audio notification";
-            this.AudioNotificationCheckBox.UseVisualStyleBackColor = true;
-            this.AudioNotificationCheckBox.CheckedChanged += new System.EventHandler(this.AudioNotificationCheckBox_CheckedChanged);
             // 
             // CarNum
             // 
@@ -311,14 +191,134 @@
             this.DriverLapNum.Resizable = System.Windows.Forms.DataGridViewTriState.False;
             this.DriverLapNum.Width = 110;
             // 
+            // TotalIncidentCountLabel
+            // 
+            this.TotalIncidentCountLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.TotalIncidentCountLabel.Font = new System.Drawing.Font("Arial", 24F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.TotalIncidentCountLabel.Location = new System.Drawing.Point(663, 31);
+            this.TotalIncidentCountLabel.Margin = new System.Windows.Forms.Padding(0);
+            this.TotalIncidentCountLabel.Name = "TotalIncidentCountLabel";
+            this.TotalIncidentCountLabel.Size = new System.Drawing.Size(288, 42);
+            this.TotalIncidentCountLabel.TabIndex = 2;
+            this.TotalIncidentCountLabel.Text = "Total Incidents";
+            this.TotalIncidentCountLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // TotalIncidentCountNum
+            // 
+            this.TotalIncidentCountNum.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.TotalIncidentCountNum.Font = new System.Drawing.Font("Arial", 60F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.TotalIncidentCountNum.Location = new System.Drawing.Point(663, 73);
+            this.TotalIncidentCountNum.Margin = new System.Windows.Forms.Padding(0);
+            this.TotalIncidentCountNum.Name = "TotalIncidentCountNum";
+            this.TotalIncidentCountNum.Size = new System.Drawing.Size(288, 100);
+            this.TotalIncidentCountNum.TabIndex = 2;
+            this.TotalIncidentCountNum.Text = "0";
+            this.TotalIncidentCountNum.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // IncidentsSinceCautionLabel
+            // 
+            this.IncidentsSinceCautionLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.IncidentsSinceCautionLabel.Font = new System.Drawing.Font("Arial", 24F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.IncidentsSinceCautionLabel.Location = new System.Drawing.Point(663, 172);
+            this.IncidentsSinceCautionLabel.Margin = new System.Windows.Forms.Padding(0);
+            this.IncidentsSinceCautionLabel.Name = "IncidentsSinceCautionLabel";
+            this.IncidentsSinceCautionLabel.Size = new System.Drawing.Size(288, 42);
+            this.IncidentsSinceCautionLabel.TabIndex = 2;
+            this.IncidentsSinceCautionLabel.Text = "Since Last Caution";
+            this.IncidentsSinceCautionLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // IncidentsSinceCautionNum
+            // 
+            this.IncidentsSinceCautionNum.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.IncidentsSinceCautionNum.Font = new System.Drawing.Font("Arial", 60F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.IncidentsSinceCautionNum.Location = new System.Drawing.Point(663, 214);
+            this.IncidentsSinceCautionNum.Margin = new System.Windows.Forms.Padding(0);
+            this.IncidentsSinceCautionNum.Name = "IncidentsSinceCautionNum";
+            this.IncidentsSinceCautionNum.Size = new System.Drawing.Size(288, 100);
+            this.IncidentsSinceCautionNum.TabIndex = 2;
+            this.IncidentsSinceCautionNum.Text = "0";
+            this.IncidentsSinceCautionNum.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // IncsRequiredForCautionTextBox
+            // 
+            this.IncsRequiredForCautionTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.IncsRequiredForCautionTextBox.Location = new System.Drawing.Point(766, 338);
+            this.IncsRequiredForCautionTextBox.Name = "IncsRequiredForCautionTextBox";
+            this.IncsRequiredForCautionTextBox.Size = new System.Drawing.Size(74, 20);
+            this.IncsRequiredForCautionTextBox.TabIndex = 3;
+            this.IncsRequiredForCautionTextBox.Text = "0";
+            this.IncsRequiredForCautionTextBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.IncsRequiredForCautionTextBox.KeyUp += new System.Windows.Forms.KeyEventHandler(this.IncsRequiredForCautionTextBox_KeyUp);
+            // 
+            // label2
+            // 
+            this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.label2.Font = new System.Drawing.Font("Arial", 9.75F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label2.Location = new System.Drawing.Point(663, 361);
+            this.label2.Margin = new System.Windows.Forms.Padding(0);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(288, 23);
+            this.label2.TabIndex = 2;
+            this.label2.Text = "(Enter to confirm)";
+            this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // CautionPanel
+            // 
+            this.CautionPanel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.CautionPanel.BackColor = System.Drawing.SystemColors.Control;
+            this.CautionPanel.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.CautionPanel.Location = new System.Drawing.Point(12, 12);
+            this.CautionPanel.MinimumSize = new System.Drawing.Size(568, 273);
+            this.CautionPanel.Name = "CautionPanel";
+            this.CautionPanel.Size = new System.Drawing.Size(591, 273);
+            this.CautionPanel.TabIndex = 4;
+            // 
+            // label4
+            // 
+            this.label4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.label4.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label4.Location = new System.Drawing.Point(663, 312);
+            this.label4.Margin = new System.Windows.Forms.Padding(0);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(288, 23);
+            this.label4.TabIndex = 2;
+            this.label4.Text = "Incs required for caution";
+            this.label4.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // AudioNotificationCheckBox
+            // 
+            this.AudioNotificationCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.AudioNotificationCheckBox.AutoSize = true;
+            this.AudioNotificationCheckBox.Font = new System.Drawing.Font("Arial", 9.75F);
+            this.AudioNotificationCheckBox.Location = new System.Drawing.Point(734, 629);
+            this.AudioNotificationCheckBox.Name = "AudioNotificationCheckBox";
+            this.AudioNotificationCheckBox.Size = new System.Drawing.Size(151, 20);
+            this.AudioNotificationCheckBox.TabIndex = 6;
+            this.AudioNotificationCheckBox.Text = "Use audio notification";
+            this.AudioNotificationCheckBox.UseVisualStyleBackColor = true;
+            this.AudioNotificationCheckBox.CheckedChanged += new System.EventHandler(this.AudioNotificationCheckBox_CheckedChanged);
+            // 
+            // ExportButton
+            // 
+            this.ExportButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.ExportButton.Font = new System.Drawing.Font("Arial", 9.75F);
+            this.ExportButton.Location = new System.Drawing.Point(506, 626);
+            this.ExportButton.Name = "ExportButton";
+            this.ExportButton.Size = new System.Drawing.Size(97, 23);
+            this.ExportButton.TabIndex = 7;
+            this.ExportButton.Text = "Export...";
+            this.ExportButton.UseVisualStyleBackColor = true;
+            this.ExportButton.Click += new System.EventHandler(this.ExportButton_Click);
+            // 
             // RaceAdminMain
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Control;
-            this.ClientSize = new System.Drawing.Size(977, 610);
+            this.ClientSize = new System.Drawing.Size(977, 661);
+            this.Controls.Add(this.ExportButton);
             this.Controls.Add(this.AudioNotificationCheckBox);
-            this.Controls.Add(this.ExportToCsvCheckBox);
             this.Controls.Add(this.CautionPanel);
             this.Controls.Add(this.IncsRequiredForCautionTextBox);
             this.Controls.Add(this.IncidentsSinceCautionNum);
@@ -330,7 +330,7 @@
             this.Controls.Add(this.IncidentsTableView);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(970, 649);
+            this.MinimumSize = new System.Drawing.Size(993, 700);
             this.Name = "RaceAdminMain";
             this.Text = "Race Administrator";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Form1_FormClosing);
@@ -350,7 +350,6 @@
         private System.Windows.Forms.TextBox IncsRequiredForCautionTextBox;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Panel CautionPanel;
-        private System.Windows.Forms.CheckBox ExportToCsvCheckBox;
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.CheckBox AudioNotificationCheckBox;
         private System.Windows.Forms.DataGridViewTextBoxColumn CarNum;
@@ -358,6 +357,7 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn Incident;
         private System.Windows.Forms.DataGridViewTextBoxColumn Total;
         private System.Windows.Forms.DataGridViewTextBoxColumn DriverLapNum;
+        private System.Windows.Forms.Button ExportButton;
     }
 }
 

--- a/RaceAdmin/RaceAdmin/Form1.Designer.cs
+++ b/RaceAdmin/RaceAdmin/Form1.Designer.cs
@@ -33,6 +33,7 @@
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle5 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle6 = new System.Windows.Forms.DataGridViewCellStyle();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(RaceAdminMain));
             this.IncidentsTableView = new System.Windows.Forms.DataGridView();
             this.CarNum = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -40,19 +41,14 @@
             this.Incident = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Total = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.DriverLapNum = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.CarNumLabel = new System.Windows.Forms.Label();
-            this.DriverNameLabel = new System.Windows.Forms.Label();
-            this.label1 = new System.Windows.Forms.Label();
             this.TotalIncidentCountLabel = new System.Windows.Forms.Label();
             this.TotalIncidentCountNum = new System.Windows.Forms.Label();
             this.IncidentsSinceCautionLabel = new System.Windows.Forms.Label();
             this.IncidentsSinceCautionNum = new System.Windows.Forms.Label();
-            this.label10 = new System.Windows.Forms.Label();
             this.IncsRequiredForCautionTextBox = new System.Windows.Forms.TextBox();
             this.label2 = new System.Windows.Forms.Label();
             this.CautionPanel = new System.Windows.Forms.Panel();
             this.ExportToCsvCheckBox = new System.Windows.Forms.CheckBox();
-            this.label3 = new System.Windows.Forms.Label();
             this.label4 = new System.Windows.Forms.Label();
             this.AudioNotificationCheckBox = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.IncidentsTableView)).BeginInit();
@@ -62,13 +58,21 @@
             // 
             this.IncidentsTableView.AllowUserToAddRows = false;
             this.IncidentsTableView.AllowUserToDeleteRows = false;
-            this.IncidentsTableView.AllowUserToResizeColumns = false;
             this.IncidentsTableView.AllowUserToResizeRows = false;
-            this.IncidentsTableView.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.IncidentsTableView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.IncidentsTableView.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.SingleVertical;
             this.IncidentsTableView.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.None;
+            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.IncidentsTableView.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
             this.IncidentsTableView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
-            this.IncidentsTableView.ColumnHeadersVisible = false;
             this.IncidentsTableView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.CarNum,
             this.DriverName,
@@ -78,7 +82,8 @@
             this.IncidentsTableView.Cursor = System.Windows.Forms.Cursors.Arrow;
             this.IncidentsTableView.EditMode = System.Windows.Forms.DataGridViewEditMode.EditProgrammatically;
             this.IncidentsTableView.EnableHeadersVisualStyles = false;
-            this.IncidentsTableView.Location = new System.Drawing.Point(12, 328);
+            this.IncidentsTableView.Location = new System.Drawing.Point(12, 291);
+            this.IncidentsTableView.MinimumSize = new System.Drawing.Size(568, 309);
             this.IncidentsTableView.Name = "IncidentsTableView";
             this.IncidentsTableView.ReadOnly = true;
             this.IncidentsTableView.RowHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.None;
@@ -93,134 +98,103 @@
             this.IncidentsTableView.ShowCellToolTips = false;
             this.IncidentsTableView.ShowEditingIcon = false;
             this.IncidentsTableView.ShowRowErrors = false;
-            this.IncidentsTableView.Size = new System.Drawing.Size(568, 272);
+            this.IncidentsTableView.Size = new System.Drawing.Size(591, 309);
             this.IncidentsTableView.TabIndex = 0;
             this.IncidentsTableView.TabStop = false;
             // 
             // CarNum
             // 
             this.CarNum.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.ControlLight;
-            dataGridViewCellStyle1.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
-            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.Color.Black;
-            dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.CarNum.DefaultCellStyle = dataGridViewCellStyle1;
-            this.CarNum.HeaderText = "CarNum";
-            this.CarNum.MinimumWidth = 75;
-            this.CarNum.Name = "CarNum";
-            this.CarNum.ReadOnly = true;
-            this.CarNum.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            this.CarNum.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            this.CarNum.Width = 75;
-            // 
-            // DriverName
-            // 
-            this.DriverName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
             dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
             dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.ControlLight;
             dataGridViewCellStyle2.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             dataGridViewCellStyle2.SelectionBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
             dataGridViewCellStyle2.SelectionForeColor = System.Drawing.Color.Black;
             dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.DriverName.DefaultCellStyle = dataGridViewCellStyle2;
-            this.DriverName.HeaderText = "DriverName";
-            this.DriverName.MinimumWidth = 250;
-            this.DriverName.Name = "DriverName";
-            this.DriverName.ReadOnly = true;
-            this.DriverName.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            this.DriverName.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            this.DriverName.Width = 250;
+            this.CarNum.DefaultCellStyle = dataGridViewCellStyle2;
+            this.CarNum.DividerWidth = 1;
+            this.CarNum.HeaderText = "Car #";
+            this.CarNum.MinimumWidth = 75;
+            this.CarNum.Name = "CarNum";
+            this.CarNum.ReadOnly = true;
+            this.CarNum.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            this.CarNum.Width = 75;
             // 
-            // Incident
+            // DriverName
             // 
-            dataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            this.DriverName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            dataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.ControlLight;
             dataGridViewCellStyle3.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             dataGridViewCellStyle3.SelectionBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
             dataGridViewCellStyle3.SelectionForeColor = System.Drawing.Color.Black;
             dataGridViewCellStyle3.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.Incident.DefaultCellStyle = dataGridViewCellStyle3;
-            this.Incident.HeaderText = "Incident";
-            this.Incident.MinimumWidth = 75;
-            this.Incident.Name = "Incident";
-            this.Incident.ReadOnly = true;
-            this.Incident.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            this.Incident.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            this.Incident.Width = 75;
+            this.DriverName.DefaultCellStyle = dataGridViewCellStyle3;
+            this.DriverName.DividerWidth = 1;
+            this.DriverName.HeaderText = "Driver Name";
+            this.DriverName.MinimumWidth = 250;
+            this.DriverName.Name = "DriverName";
+            this.DriverName.ReadOnly = true;
+            this.DriverName.Resizable = System.Windows.Forms.DataGridViewTriState.True;
             // 
-            // Total
+            // Incident
             // 
+            this.Incident.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
             dataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
             dataGridViewCellStyle4.BackColor = System.Drawing.SystemColors.ControlLight;
             dataGridViewCellStyle4.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             dataGridViewCellStyle4.SelectionBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
             dataGridViewCellStyle4.SelectionForeColor = System.Drawing.Color.Black;
             dataGridViewCellStyle4.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.Total.DefaultCellStyle = dataGridViewCellStyle4;
-            this.Total.HeaderText = "Total";
-            this.Total.MinimumWidth = 75;
-            this.Total.Name = "Total";
-            this.Total.ReadOnly = true;
-            this.Total.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            this.Total.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            this.Total.Width = 75;
+            this.Incident.DefaultCellStyle = dataGridViewCellStyle4;
+            this.Incident.DividerWidth = 1;
+            this.Incident.HeaderText = "Inc.";
+            this.Incident.MinimumWidth = 75;
+            this.Incident.Name = "Incident";
+            this.Incident.ReadOnly = true;
+            this.Incident.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            this.Incident.Width = 75;
             // 
-            // DriverLapNum
+            // Total
             // 
+            this.Total.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
             dataGridViewCellStyle5.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
             dataGridViewCellStyle5.BackColor = System.Drawing.SystemColors.ControlLight;
             dataGridViewCellStyle5.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             dataGridViewCellStyle5.SelectionBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
             dataGridViewCellStyle5.SelectionForeColor = System.Drawing.Color.Black;
             dataGridViewCellStyle5.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.DriverLapNum.DefaultCellStyle = dataGridViewCellStyle5;
-            this.DriverLapNum.HeaderText = "DriverLapNum";
-            this.DriverLapNum.MinimumWidth = 95;
+            this.Total.DefaultCellStyle = dataGridViewCellStyle5;
+            this.Total.DividerWidth = 1;
+            this.Total.HeaderText = "Total";
+            this.Total.MinimumWidth = 75;
+            this.Total.Name = "Total";
+            this.Total.ReadOnly = true;
+            this.Total.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            this.Total.Width = 75;
+            // 
+            // DriverLapNum
+            // 
+            this.DriverLapNum.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            dataGridViewCellStyle6.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            dataGridViewCellStyle6.BackColor = System.Drawing.SystemColors.ControlLight;
+            dataGridViewCellStyle6.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle6.SelectionBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
+            dataGridViewCellStyle6.SelectionForeColor = System.Drawing.Color.Black;
+            dataGridViewCellStyle6.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.DriverLapNum.DefaultCellStyle = dataGridViewCellStyle6;
+            this.DriverLapNum.HeaderText = "Driver Lap #";
+            this.DriverLapNum.MinimumWidth = 93;
             this.DriverLapNum.Name = "DriverLapNum";
             this.DriverLapNum.ReadOnly = true;
             this.DriverLapNum.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            this.DriverLapNum.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            this.DriverLapNum.Width = 95;
-            // 
-            // CarNumLabel
-            // 
-            this.CarNumLabel.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.CarNumLabel.Location = new System.Drawing.Point(11, 302);
-            this.CarNumLabel.Margin = new System.Windows.Forms.Padding(0);
-            this.CarNumLabel.Name = "CarNumLabel";
-            this.CarNumLabel.Size = new System.Drawing.Size(75, 23);
-            this.CarNumLabel.TabIndex = 2;
-            this.CarNumLabel.Text = "Car #";
-            this.CarNumLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // DriverNameLabel
-            // 
-            this.DriverNameLabel.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.DriverNameLabel.Location = new System.Drawing.Point(90, 302);
-            this.DriverNameLabel.Margin = new System.Windows.Forms.Padding(0);
-            this.DriverNameLabel.Name = "DriverNameLabel";
-            this.DriverNameLabel.Size = new System.Drawing.Size(250, 23);
-            this.DriverNameLabel.TabIndex = 2;
-            this.DriverNameLabel.Text = "Driver Name";
-            this.DriverNameLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // label1
-            // 
-            this.label1.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label1.Location = new System.Drawing.Point(490, 302);
-            this.label1.Margin = new System.Windows.Forms.Padding(0);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(95, 23);
-            this.label1.TabIndex = 2;
-            this.label1.Text = "Driver Lap #";
-            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.DriverLapNum.Width = 93;
             // 
             // TotalIncidentCountLabel
             // 
+            this.TotalIncidentCountLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.TotalIncidentCountLabel.Font = new System.Drawing.Font("Arial", 24F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.TotalIncidentCountLabel.Location = new System.Drawing.Point(640, 31);
+            this.TotalIncidentCountLabel.Location = new System.Drawing.Point(663, 31);
             this.TotalIncidentCountLabel.Margin = new System.Windows.Forms.Padding(0);
             this.TotalIncidentCountLabel.Name = "TotalIncidentCountLabel";
             this.TotalIncidentCountLabel.Size = new System.Drawing.Size(288, 42);
@@ -230,8 +204,9 @@
             // 
             // TotalIncidentCountNum
             // 
+            this.TotalIncidentCountNum.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.TotalIncidentCountNum.Font = new System.Drawing.Font("Arial", 60F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.TotalIncidentCountNum.Location = new System.Drawing.Point(640, 73);
+            this.TotalIncidentCountNum.Location = new System.Drawing.Point(663, 73);
             this.TotalIncidentCountNum.Margin = new System.Windows.Forms.Padding(0);
             this.TotalIncidentCountNum.Name = "TotalIncidentCountNum";
             this.TotalIncidentCountNum.Size = new System.Drawing.Size(288, 100);
@@ -241,8 +216,9 @@
             // 
             // IncidentsSinceCautionLabel
             // 
+            this.IncidentsSinceCautionLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.IncidentsSinceCautionLabel.Font = new System.Drawing.Font("Arial", 24F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.IncidentsSinceCautionLabel.Location = new System.Drawing.Point(640, 172);
+            this.IncidentsSinceCautionLabel.Location = new System.Drawing.Point(663, 172);
             this.IncidentsSinceCautionLabel.Margin = new System.Windows.Forms.Padding(0);
             this.IncidentsSinceCautionLabel.Name = "IncidentsSinceCautionLabel";
             this.IncidentsSinceCautionLabel.Size = new System.Drawing.Size(288, 42);
@@ -252,8 +228,9 @@
             // 
             // IncidentsSinceCautionNum
             // 
+            this.IncidentsSinceCautionNum.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.IncidentsSinceCautionNum.Font = new System.Drawing.Font("Arial", 60F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.IncidentsSinceCautionNum.Location = new System.Drawing.Point(640, 214);
+            this.IncidentsSinceCautionNum.Location = new System.Drawing.Point(663, 214);
             this.IncidentsSinceCautionNum.Margin = new System.Windows.Forms.Padding(0);
             this.IncidentsSinceCautionNum.Name = "IncidentsSinceCautionNum";
             this.IncidentsSinceCautionNum.Size = new System.Drawing.Size(288, 100);
@@ -261,20 +238,10 @@
             this.IncidentsSinceCautionNum.Text = "0";
             this.IncidentsSinceCautionNum.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
-            // label10
-            // 
-            this.label10.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label10.Location = new System.Drawing.Point(346, 302);
-            this.label10.Margin = new System.Windows.Forms.Padding(0);
-            this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(66, 23);
-            this.label10.TabIndex = 2;
-            this.label10.Text = "Inc.";
-            this.label10.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
             // IncsRequiredForCautionTextBox
             // 
-            this.IncsRequiredForCautionTextBox.Location = new System.Drawing.Point(743, 338);
+            this.IncsRequiredForCautionTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.IncsRequiredForCautionTextBox.Location = new System.Drawing.Point(766, 338);
             this.IncsRequiredForCautionTextBox.Name = "IncsRequiredForCautionTextBox";
             this.IncsRequiredForCautionTextBox.Size = new System.Drawing.Size(74, 20);
             this.IncsRequiredForCautionTextBox.TabIndex = 3;
@@ -284,8 +251,9 @@
             // 
             // label2
             // 
+            this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label2.Font = new System.Drawing.Font("Arial", 9.75F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label2.Location = new System.Drawing.Point(640, 361);
+            this.label2.Location = new System.Drawing.Point(663, 361);
             this.label2.Margin = new System.Windows.Forms.Padding(0);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(288, 23);
@@ -295,39 +263,33 @@
             // 
             // CautionPanel
             // 
+            this.CautionPanel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.CautionPanel.BackColor = System.Drawing.SystemColors.Control;
             this.CautionPanel.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.CautionPanel.Location = new System.Drawing.Point(12, 12);
+            this.CautionPanel.MinimumSize = new System.Drawing.Size(568, 273);
             this.CautionPanel.Name = "CautionPanel";
-            this.CautionPanel.Size = new System.Drawing.Size(568, 273);
+            this.CautionPanel.Size = new System.Drawing.Size(591, 273);
             this.CautionPanel.TabIndex = 4;
             // 
             // ExportToCsvCheckBox
             // 
+            this.ExportToCsvCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.ExportToCsvCheckBox.AutoSize = true;
             this.ExportToCsvCheckBox.Font = new System.Drawing.Font("Arial", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.ExportToCsvCheckBox.Location = new System.Drawing.Point(661, 580);
+            this.ExportToCsvCheckBox.Location = new System.Drawing.Point(684, 578);
             this.ExportToCsvCheckBox.Name = "ExportToCsvCheckBox";
             this.ExportToCsvCheckBox.Size = new System.Drawing.Size(237, 20);
             this.ExportToCsvCheckBox.TabIndex = 5;
             this.ExportToCsvCheckBox.Text = "Export incident table to csv on close";
             this.ExportToCsvCheckBox.UseVisualStyleBackColor = true;
             // 
-            // label3
-            // 
-            this.label3.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label3.Location = new System.Drawing.Point(417, 302);
-            this.label3.Margin = new System.Windows.Forms.Padding(0);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(67, 23);
-            this.label3.TabIndex = 2;
-            this.label3.Text = "Total";
-            this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
             // label4
             // 
+            this.label4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label4.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label4.Location = new System.Drawing.Point(640, 312);
+            this.label4.Location = new System.Drawing.Point(663, 312);
             this.label4.Margin = new System.Windows.Forms.Padding(0);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(288, 23);
@@ -337,9 +299,10 @@
             // 
             // AudioNotificationCheckBox
             // 
+            this.AudioNotificationCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.AudioNotificationCheckBox.AutoSize = true;
             this.AudioNotificationCheckBox.Font = new System.Drawing.Font("Arial", 9.75F);
-            this.AudioNotificationCheckBox.Location = new System.Drawing.Point(661, 557);
+            this.AudioNotificationCheckBox.Location = new System.Drawing.Point(684, 555);
             this.AudioNotificationCheckBox.Name = "AudioNotificationCheckBox";
             this.AudioNotificationCheckBox.Size = new System.Drawing.Size(151, 20);
             this.AudioNotificationCheckBox.TabIndex = 6;
@@ -352,7 +315,7 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Control;
-            this.ClientSize = new System.Drawing.Size(954, 612);
+            this.ClientSize = new System.Drawing.Size(977, 610);
             this.Controls.Add(this.AudioNotificationCheckBox);
             this.Controls.Add(this.ExportToCsvCheckBox);
             this.Controls.Add(this.CautionPanel);
@@ -361,16 +324,12 @@
             this.Controls.Add(this.IncidentsSinceCautionLabel);
             this.Controls.Add(this.TotalIncidentCountNum);
             this.Controls.Add(this.TotalIncidentCountLabel);
-            this.Controls.Add(this.label1);
             this.Controls.Add(this.label4);
             this.Controls.Add(this.label2);
-            this.Controls.Add(this.DriverNameLabel);
-            this.Controls.Add(this.label3);
-            this.Controls.Add(this.label10);
-            this.Controls.Add(this.CarNumLabel);
             this.Controls.Add(this.IncidentsTableView);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(970, 649);
             this.Name = "RaceAdminMain";
             this.Text = "Race Administrator";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Form1_FormClosing);
@@ -383,26 +342,21 @@
         #endregion
 
         private System.Windows.Forms.DataGridView IncidentsTableView;
-        private System.Windows.Forms.Label CarNumLabel;
-        private System.Windows.Forms.Label DriverNameLabel;
-        private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Label TotalIncidentCountLabel;
         private System.Windows.Forms.Label TotalIncidentCountNum;
         private System.Windows.Forms.Label IncidentsSinceCautionLabel;
         private System.Windows.Forms.Label IncidentsSinceCautionNum;
-        private System.Windows.Forms.Label label10;
         private System.Windows.Forms.TextBox IncsRequiredForCautionTextBox;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Panel CautionPanel;
         private System.Windows.Forms.CheckBox ExportToCsvCheckBox;
-        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.CheckBox AudioNotificationCheckBox;
         private System.Windows.Forms.DataGridViewTextBoxColumn CarNum;
         private System.Windows.Forms.DataGridViewTextBoxColumn DriverName;
         private System.Windows.Forms.DataGridViewTextBoxColumn Incident;
         private System.Windows.Forms.DataGridViewTextBoxColumn Total;
         private System.Windows.Forms.DataGridViewTextBoxColumn DriverLapNum;
-        private System.Windows.Forms.Label label4;
-        private System.Windows.Forms.CheckBox AudioNotificationCheckBox;
     }
 }
 

--- a/RaceAdmin/RaceAdmin/Form1.cs
+++ b/RaceAdmin/RaceAdmin/Form1.cs
@@ -320,7 +320,7 @@ namespace RaceAdmin
         /// </summary>
         /// <param name="driver">Driver associated with the latest incident.</param>
         /// <param name="delta">The number of incident points gained by this driver on this occasion.</param>
-        private void LogNewIncident(Driver driver, int delta)
+        public void LogNewIncident(Driver driver, int delta)
         {
             StringBuilder sb = new StringBuilder();
             int rowId = IncidentsTableView.Rows.Add();
@@ -397,16 +397,19 @@ namespace RaceAdmin
         /// <param name="e">EventArgs event.</param>
         private void ExportButton_Click(object sender, EventArgs e)
         {
-            var saveFileDialog = new SaveFileDialog();
-            saveFileDialog.FileName = DateTime.Now.ToString("yyyy-MM-dd HH-mm-ss") + ".csv";
-            saveFileDialog.Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*";
-            saveFileDialog.FilterIndex = 1;
-            saveFileDialog.RestoreDirectory = true;
+            var saveFileDialog = new SaveFileDialog
+            {
+                Title = "Export...",
+                FileName = DateTime.Now.ToString("yyyy-MM-dd HH-mm-ss") + ".csv",
+                Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*",
+                FilterIndex = 1,
+                RestoreDirectory = true
+            };
 
             if (saveFileDialog.ShowDialog() == DialogResult.OK)
             {
-                Stream outputStream;
-                if ((outputStream = saveFileDialog.OpenFile()) != null)
+                Stream outputStream = saveFileDialog.OpenFile();
+                if (outputStream != null)
                 {
                     var outputWriter = new StreamWriter(outputStream);
                     ExportIncidentTableToCsv(outputWriter);
@@ -419,7 +422,7 @@ namespace RaceAdmin
         /// Exports the contents of the IncidentsTableView to the given writer in CSV format.
         /// </summary>
         /// <param name="writer">The TextWriter to which the contents should be written.</param>
-        private void ExportIncidentTableToCsv(TextWriter writer)
+        public void ExportIncidentTableToCsv(TextWriter writer)
         {
             // write the column headers
             var headers = IncidentsTableView.Columns.Cast<DataGridViewColumn>();
@@ -508,7 +511,7 @@ namespace RaceAdmin
 
         private int testCurrentLap = 1;
 
-        private void Test_AddIncidentRow_Click(object sender, EventArgs e)
+        private void Test_AddIncidentRow(object sender, EventArgs e)
         {
             testCurrentLap = MakeRandomLap();
 

--- a/RaceAdmin/RaceAdmin/Form1.cs
+++ b/RaceAdmin/RaceAdmin/Form1.cs
@@ -475,20 +475,43 @@ namespace RaceAdmin
             }
         }
 
+        public void IncidentsTableView_SortCompare(object sender, DataGridViewSortCompareEventArgs e)
+        {
+            if ("CarNum".Equals(e.Column.Name))
+            {
+                var v1 = e.CellValue1.ToString();
+                var v2 = e.CellValue2.ToString();
+                var result = v1.Length - v2.Length;
+                if (result == 0)
+                {
+                    var num1 = Int32.Parse(v1);
+                    var num2 = Int32.Parse(v2);
+                    result = num1 - num2;
+                }
+                e.SortResult = result;
+                e.Handled = true;
+            }
+            else
+            {
+                e.Handled = false;
+            }
+        }
+
         // Code below this comment is used to generate test data or to simulate behavior 
         // for UI testing. To use, create buttons on the form and connect them to the various
         // event handler methods below.
 
         private int testCurrentLap = 1;
 
-        private void AddIncidentRow_Click(object sender, EventArgs e)
+        private void Test_AddIncidentRow_Click(object sender, EventArgs e)
         {
             testCurrentLap = MakeRandomLap();
 
             var rng = new Random();
             var newIncidents = (int)Math.Pow(2, rng.Next(3));
 
-            Driver driver = new Driver() {
+            Driver driver = new Driver()
+            {
                 CarIdx = 0,
                 FullName = MakeRandomName(),
                 CarNum = MakeRandomCarNumber(),
@@ -552,5 +575,10 @@ namespace RaceAdmin
             var rng = new Random();
             return testCurrentLap + rng.Next(2);
         }
+
+        // Code above this comment is used to generate test data or to simulate behavior 
+        // for UI testing. To use, create buttons on the form and connect them to the various
+        // event handler methods above.
+
     }
 }

--- a/RaceAdmin/RaceAdmin/Form1.cs
+++ b/RaceAdmin/RaceAdmin/Form1.cs
@@ -391,51 +391,56 @@ namespace RaceAdmin
         }
 
         /// <summary>
-        /// Exports the contents of the IncidentsTableView to a csv file.
+        /// Exports the incidents table to a CSV file when the Export... button is clicked.
         /// </summary>
-        private void ExportIncidentTableToCsv()
+        /// <param name="sender">Sender of the event.</param>
+        /// <param name="e">EventArgs event.</param>
+        private void ExportButton_Click(object sender, EventArgs e)
         {
-            // Check for csv folder, create if it doesn't exist.
-            StringBuilder csvPath = new StringBuilder();
-            csvPath.Append(Path.GetDirectoryName(Application.ExecutablePath));
-            csvPath.Append(@"\csv");
-            Directory.CreateDirectory(csvPath.ToString());
+            var saveFileDialog = new SaveFileDialog();
+            saveFileDialog.FileName = DateTime.Now.ToString("yyyy-MM-dd HH-mm-ss") + ".csv";
+            saveFileDialog.Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*";
+            saveFileDialog.FilterIndex = 1;
+            saveFileDialog.RestoreDirectory = true;
 
-            // Set path and filename for the csv file.
-            DateTime dateTime = DateTime.Now;
-            csvPath.Append(@"\");
-            csvPath.Append(dateTime.ToString("yyyy-MM-dd HH-mm-ss"));
-            csvPath.Append(@".csv");
+            if (saveFileDialog.ShowDialog() == DialogResult.OK)
+            {
+                Stream outputStream;
+                if ((outputStream = saveFileDialog.OpenFile()) != null)
+                {
+                    var outputWriter = new StreamWriter(outputStream);
+                    ExportIncidentTableToCsv(outputWriter);
+                    outputWriter.Close();
+                }
+            }
+        }
 
-            // Iterate through each row of the incident table and build a string to write to the csv file.
-            StringBuilder csvString = new StringBuilder();
+        /// <summary>
+        /// Exports the contents of the IncidentsTableView to the given writer in CSV format.
+        /// </summary>
+        /// <param name="writer">The TextWriter to which the contents should be written.</param>
+        private void ExportIncidentTableToCsv(TextWriter writer)
+        {
+            // write the column headers
             var headers = IncidentsTableView.Columns.Cast<DataGridViewColumn>();
-            csvString.AppendLine(string.Join(",", headers.Select(column => "\"" + column.HeaderText + "\"").ToArray()));
+            writer.WriteLine(string.Join(",", headers.Select(column => "\"" + column.HeaderText + "\"").ToArray()));
 
+            // iterate through each row of the incidents table and write
             foreach (DataGridViewRow row in IncidentsTableView.Rows)
             {
                 var cells = row.Cells.Cast<DataGridViewCell>();
-                csvString.AppendLine(string.Join(",", cells.Select(cell => "\"" + cell.Value + "\"").ToArray()));
+                writer.WriteLine(string.Join(",", cells.Select(cell => "\"" + cell.Value + "\"").ToArray()));
             }
-
-            // Write to the csv file.
-            File.WriteAllText(csvPath.ToString(), csvString.ToString());
         }
 
         /// <summary>
         /// Closes the current environment when the X button is clicked.
-        /// Checks if user wants to export the incident table to csv.
         /// </summary>
         /// <param name="sender">Sender of the event.</param>
         /// <param name="e">FormClosing event.</param>
         private void Form1_FormClosing(object sender, FormClosingEventArgs e)
         {
             wrapper.Stop();
-            if (ExportToCsvCheckBox.Checked == true)
-            {
-                ExportIncidentTableToCsv();
-            }
-
             Environment.Exit(0);
         }
 

--- a/RaceAdmin/RaceAdmin/Form1.cs
+++ b/RaceAdmin/RaceAdmin/Form1.cs
@@ -475,5 +475,82 @@ namespace RaceAdmin
             }
         }
 
+        // Code below this comment is used to generate test data or to simulate behavior 
+        // for UI testing. To use, create buttons on the form and connect them to the various
+        // event handler methods below.
+
+        private int testCurrentLap = 1;
+
+        private void AddIncidentRow_Click(object sender, EventArgs e)
+        {
+            testCurrentLap = MakeRandomLap();
+
+            var rng = new Random();
+            var newIncidents = (int)Math.Pow(2, rng.Next(3));
+
+            Driver driver = new Driver() {
+                CarIdx = 0,
+                FullName = MakeRandomName(),
+                CarNum = MakeRandomCarNumber(),
+                IRating = "",
+                OldIncs = 0,
+                NewIncs = newIncidents,
+                CurrentLap = testCurrentLap
+            };
+
+            LogNewIncident(driver, newIncidents);
+        }
+
+        private static string MakeRandomName()
+        {
+            var rng = new Random();
+            var names = rng.Next(2, 5);
+
+            var name = new StringBuilder();
+            for (var i = 0; i < names; i++)
+            {
+                var characters = rng.Next(8) + 3;
+                for (var j = 0; j < characters; j++)
+                {
+                    var character = (char)rng.Next('a', 'z');
+                    if (j == 0)
+                    {
+                        character = character.ToString().ToUpper()[0];
+                    }
+                    name.Append(character);
+                }
+                if (i < (names - 1))
+                {
+                    if (rng.NextDouble() < 0.05)
+                    {
+                        name.Append("-");
+                    }
+                    else
+                    {
+                        name.Append(" ");
+                    }
+                }
+            }
+            return name.ToString();
+        }
+
+        private string MakeRandomCarNumber()
+        {
+            var rng = new Random();
+            var digits = rng.Next(3) + 1;
+            var sb = new StringBuilder();
+            for (var i = 0; i < digits; i++)
+            {
+                var digit = rng.Next(10);
+                sb.Append(digit.ToString());
+            }
+            return sb.ToString();
+        }
+
+        private int MakeRandomLap()
+        {
+            var rng = new Random();
+            return testCurrentLap + rng.Next(2);
+        }
     }
 }


### PR DESCRIPTION
Note: this PR needs to be merged only after https://github.com/CaptJeanLuc1701/RaceAdmin/pull/4

Adds an "Export..." button that allows the incident table to be exported to a CSV whenever the user chooses. The export-on-close checkbox has been removed. The "Export..." button now brings up a SaveFileDialog to allow the user to choose a location and name.

Also brought the export functionality under test.

